### PR TITLE
Update main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -263,10 +263,10 @@ async function run(platform: Platform): Promise<void> {
 
     // Add environment variables
     core.startGroup(`🔧 Adding environment variables...`)
-    core.exportVariable('GODOT', godotAlias)
-    core.info(`  GODOT=${godotAlias}`)
-    core.exportVariable('GODOT4', godotAlias)
-    core.info(`  GODOT4=${godotAlias}`)
+    core.exportVariable('GODOT', godotExecutable)
+    core.info(`  GODOT=${godotExecutable}`)
+    core.exportVariable('GODOT4', godotExecutable)
+    core.info(`  GODOT4=${godotExecutable}`)
     core.info(`✅ Environment variables added`)
     core.endGroup()
 


### PR DESCRIPTION
if you run that script using a windows runner in github workflows, then it cannot create symlinks because in windows you need admin rights to do so.  github does not provide the runner with such permisions. therefore the symlink simply does not work.

It should- however - work when you directly set the environment variable to the path of th executable. 

I hope I did not miss, why those symlinks were set in the first place and that they are not needed somewhere else?