### PR TITLE
doc: update badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ For that to work, your project must have a `global.json` file in the root direct
 <Project Sdk="Godot.NET.Sdk/4.0.0"> <!-- BAD -->
 ```
 
-[chickensoft-badge]: https://raw.githubusercontent.com/chickensoft-games/chickensoft_site/main/static/img/badges/chickensoft_badge.svg
+[chickensoft-badge]: https://chickensoft.games/img/badges/chickensoft_badge.svg
 [chickensoft-website]: https://chickensoft.games
-[discord-badge]: https://raw.githubusercontent.com/chickensoft-games/chickensoft_site/main/static/img/badges/discord_badge.svg
+[discord-badge]: https://chickensoft.games/img/badges/discord_badge.svg
 [discord]: https://discord.gg/gSjaPgMmYW
-[read-the-docs-badge]: https://raw.githubusercontent.com/chickensoft-games/chickensoft_site/main/static/img/badges/read_the_docs_badge.svg
+[read-the-docs-badge]: https://chickensoft.games/img/badges/read_the_docs_badge.svg
 [docs]: https://chickensoft.games/docs
 [action]: ./action.yml
 [GodotSharp]: https://www.nuget.org/packages/GodotSharp#versions-body-tab


### PR DESCRIPTION
Updated badge URLs in README to match the new Chickensoft site.